### PR TITLE
Fix pipeline integration tests by adding sample content fixture

### DIFF
--- a/scripts/test_data/sample.md
+++ b/scripts/test_data/sample.md
@@ -1,0 +1,24 @@
+# Sample Gazetteer
+
+## Overview
+This is a sample document about the bustling town of Miral. Enconnters are frequent and the town council meets weekly.
+
+## Commerce
+Armor, steel mail, (full chain mail), 10 weeks' work
+125gp
+point restored per
+
+### Market Stalls
+The smith produces wares that residents say are conrts level quality and the warehouse district is thriving.
+
+### Long Line Example
+This paragraph intentionally contains a particularly elongated sentence that stretches beyond one hundred and twenty characters so the long line detector has meaningful work to do during the integration test.
+
+## Tables
+| Item | Cost |
+| --- | --- |
+| Iron Rations | 5gp |
+| Shield | 12gp |
+
+## Notes
+This section ensures we test spacing issues , like misplaced commas , and words such as Sonth that should become South.

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -11,12 +11,20 @@ import re
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 # Import pipeline tools
+import pytest
 from tools.markdown_header_depth_corrector import HeaderCorrector
 from tools.markdown_cleanup_fixer import MarkdownCleanupFixer
 from tools.fix_table_formatting import fix_table_formatting
 from tools.fix_ocr_errors import fix_ocr_errors
 from tools.fix_additional_ocr_errors import fix_additional_ocr_errors
 from tools.long_line_detector import LongLineDetector
+
+
+@pytest.fixture(scope="module")
+def content():
+    """Load sample markdown content for pipeline checks."""
+    sample_path = Path(__file__).resolve().parent / "test_data" / "sample.md"
+    return sample_path.read_text(encoding="utf-8")
 
 def print_header(title):
     print(f"\n{'='*80}\n{title}\n{'='*80}")


### PR DESCRIPTION
## Summary
- add a pytest fixture that loads sample markdown content for the pipeline tests
- include a representative sample markdown document used by the tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6904f3213714832fb4e889830bf9f8ea